### PR TITLE
docs: add usage and API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This gem is a [esse](https://github.com/marcosgz/esse) plugin for the [pagy](https://github.com/ddnexus/pagy) pagination.
 
+## Documentation
+
+Full guides, pagination examples, and API reference are published at **[gems.marcosz.com.br/esse-pagy](https://gems.marcosz.com.br/esse-pagy/)** — part of the [marcosgz Ruby gem catalogue](https://gems.marcosz.com.br).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# esse-pagy
+
+[Pagy](https://github.com/ddnexus/pagy) pagination for [Esse](../../esse/docs/README.md) search queries.
+
+Unlike `esse-kaminari`, which adds chainable query methods, `esse-pagy` uses Pagy's **controller-backend** pattern: the index builds a delayed search description, and the `pagy_esse` controller helper executes it with pagination.
+
+## Contents
+
+- [Usage guide](usage.md)
+- [API reference](api.md)
+
+## Install
+
+```ruby
+# Gemfile
+gem 'esse', '>= 0.2.4'
+gem 'pagy', '>= 5'
+gem 'esse-pagy'
+```
+
+In your controller (Pagy's `Pagy::Backend` is typically included in `ApplicationController`):
+
+```ruby
+class UsersController < ApplicationController
+  def index
+    @pagy, @response = pagy_esse(
+      UsersIndex.pagy_search(body: { query: { match: { name: params[:q] } } }),
+      items: 10
+    )
+    @results = @response.results
+  end
+end
+```
+
+In the view:
+
+```erb
+<%== pagy_nav(@pagy) %>
+<% @results.each { |hit| %><%= hit.dig('_source', 'name') %><br><% } %>
+```
+
+## Multi-index pagination
+
+```ruby
+@pagy, @response = pagy_esse(
+  Esse.cluster.pagy_search(CitiesIndex, CountiesIndex, body: body),
+  items: 25
+)
+```
+
+## Version
+
+- Version: **0.0.1**
+- Ruby: `>= 2.5.0`
+- Depends on: `esse >= 0.2.4`, `pagy >= 5`
+
+## License
+
+MIT.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,125 @@
+# API Reference
+
+The gem adds methods at four layers:
+
+1. `Esse::Index.pagy_search` — build a deferred search description.
+2. `Esse::Cluster#pagy_search` — same, for multi-index/cluster searches.
+3. `Pagy.new_from_esse` — build a Pagy instance from an already-executed query.
+4. `Pagy::Backend#pagy_esse` — controller helper that executes the description with pagination.
+
+---
+
+## `Esse::Index.pagy_search`
+
+Module: `Esse::Pagy::IndexSearch` (extended into `Esse::Index`).
+
+### `.pagy_search(q = nil, **kwargs, &block) → Array`
+
+Returns `[cluster, self, { q: q, **kwargs }, block]` — a **description** of what to search, not an actual search.
+
+```ruby
+args = UsersIndex.pagy_search(body: { query: { match_all: {} } })
+# => [UsersIndex.cluster, UsersIndex, { body: {...} }, nil]
+```
+
+Alias configurable via `Pagy::DEFAULT[:esse_pagy_search]` (default: `:pagy_search`).
+
+---
+
+## `Esse::Cluster#pagy_search`
+
+Module: `Esse::Pagy::ClusterSearch` (prepended into `Esse::Cluster`).
+
+### `#pagy_search(*indices, **kwargs, &block) → Array`
+
+Returns `[self, indices, kwargs, block]`.
+
+```ruby
+Esse.cluster.pagy_search(CitiesIndex, CountiesIndex, body: { ... })
+```
+
+Indices can be classes, strings, or wildcard patterns.
+
+---
+
+## `Pagy.new_from_esse`
+
+Module: `Esse::Pagy::ClassMethods` (extended into `Pagy`).
+
+### `Pagy.new_from_esse(query, vars = {}) → Pagy`
+
+Builds a Pagy instance from an already-executed `Esse::Search::Query`.
+
+```ruby
+query = UsersIndex.search(body: body).limit(10).offset(20)
+pagy  = Pagy.new_from_esse(query)
+```
+
+Internally:
+
+```ruby
+vars[:count] = query.response.total
+vars[:page]  = (query.offset_value / query.limit_value.to_f).ceil + 1
+vars[:items] = query.limit_value
+Pagy.new(vars)
+```
+
+---
+
+## `Pagy::Backend#pagy_esse`
+
+Module: `Esse::Pagy::Backend` (prepended into `Pagy::Backend`).
+
+### `#pagy_esse(pagy_search_args, vars = {}) → [Pagy, Esse::Search::Query]`
+
+Executes the deferred search with pagination applied.
+
+```ruby
+@pagy, @response = pagy_esse(UsersIndex.pagy_search(body: body), items: 10)
+```
+
+Flow:
+
+1. Extract `cluster, indices, kwargs, block` from the description.
+2. Merge pagination vars with `params` (uses `Pagy::DEFAULT[:page_param]` and `Pagy::DEFAULT[:items]`).
+3. Build the query by calling the search method (default `.search`, configurable via `Pagy::DEFAULT[:esse_search]`) and applying `.limit(items).offset((page - 1) * items)`.
+4. Extract total count from `query.response.total`.
+5. Construct a `Pagy` instance.
+6. Handle `overflow: :last_page` if `Pagy::OverflowExtra` is loaded.
+7. Return `[pagy, query]`.
+
+### `#pagy_esse_get_vars(_query, vars)`
+
+Helper: merges Pagy configuration and request params into the vars hash.
+
+| Precedence (high → low) | Source |
+|-------------------------|--------|
+| Explicit `vars[:page]` / `vars[:items]` | caller |
+| `params[page_param]`, `params[:items]` | request |
+| `Pagy::DEFAULT[:items]` | config |
+
+---
+
+## Pagy configuration keys used
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `Pagy::DEFAULT[:esse_search]` | `:search` | Name of the search method to call (`.search` by default) |
+| `Pagy::DEFAULT[:esse_pagy_search]` | `:pagy_search` | Alias name for the deferred-search method |
+| `Pagy::DEFAULT[:items]` | Pagy default | Items per page fallback |
+| `Pagy::DEFAULT[:page_param]` | `:page` | Request parameter name for page |
+
+---
+
+## Integration summary
+
+On load:
+
+```ruby
+Esse::Index.extend(Esse::Pagy::IndexSearch)
+Esse::Cluster.prepend(Esse::Pagy::ClusterSearch)
+Pagy::Backend.prepend(Esse::Pagy::Backend)
+Pagy.extend(Esse::Pagy::ClassMethods)
+```
+
+No configuration is required beyond whatever Pagy setup you already have.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,140 @@
+# Usage Guide
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'esse'
+gem 'pagy'
+gem 'esse-pagy'
+```
+
+Loading the gem:
+
+- Extends every `Esse::Index` with `pagy_search`.
+- Prepends `pagy_search` into `Esse::Cluster`.
+- Adds `pagy_esse` to `Pagy::Backend` (already included in your controllers).
+- Adds `Pagy.new_from_esse`.
+
+No initializer needed.
+
+## Basic controller usage
+
+```ruby
+class UsersController < ApplicationController
+  def index
+    @pagy, @response = pagy_esse(
+      UsersIndex.pagy_search(body: { query: { match_all: {} } }),
+      items: 10
+    )
+  end
+end
+```
+
+- `UsersIndex.pagy_search(...)` returns a deferred "search description" (it does **not** execute a query).
+- `pagy_esse(description, **vars)` executes the search with the pagination info pulled from `params` (or provided `vars`) and returns `[pagy_instance, query_or_response]`.
+
+## Rendering
+
+```erb
+<%== pagy_nav(@pagy) %>
+
+<% @response.results.each do |hit| %>
+  <%= hit.dig('_source', 'name') %>
+<% end %>
+```
+
+## Multiple indices / cluster search
+
+Use `Esse.cluster.pagy_search`:
+
+```ruby
+@pagy, @response = pagy_esse(
+  Esse.cluster.pagy_search(CitiesIndex, CountiesIndex, body: body),
+  items: 20
+)
+```
+
+You can also pass wildcard index names:
+
+```ruby
+@pagy, @response = pagy_esse(
+  Esse.cluster.pagy_search('geos_*', body: { query: { match_all: {} } }),
+  items: 15
+)
+```
+
+## Passing a query-modification block
+
+The block is forwarded to the underlying `search` call:
+
+```ruby
+@pagy, @response = pagy_esse(
+  UsersIndex.pagy_search("*") { |query| query.filter('status', 'active') },
+  items: 10
+)
+```
+
+## Reading params
+
+By default `pagy_esse` reads `params[:page]` and `params[:items]`:
+
+```
+/users?page=2&items=25
+```
+
+Override by passing `vars`:
+
+```ruby
+pagy_esse(description, page: 3, items: 50)
+```
+
+Pagy's standard configuration applies:
+
+```ruby
+# config/initializers/pagy.rb
+Pagy::DEFAULT[:items] = 20
+Pagy::DEFAULT[:page_param] = :p
+```
+
+## Creating a Pagy from an executed query
+
+If you have a query already executed, use:
+
+```ruby
+query = UsersIndex.search(body: body).limit(10).offset(20)
+pagy  = Pagy.new_from_esse(query)
+
+# pagy.page  => 3
+# pagy.items => 10
+# pagy.count => total hits
+```
+
+## Overflow handling
+
+With `Pagy::OverflowExtra` loaded:
+
+```ruby
+@pagy, @response = pagy_esse(description, items: 10, overflow: :last_page)
+```
+
+When the requested page is beyond the available pages, Pagy falls back to the last valid page instead of raising `Pagy::OverflowError`.
+
+## Customizing method names
+
+The default method is `pagy_search`, aliased from `pagy_esse`. Change the alias name via Pagy's defaults:
+
+```ruby
+Pagy::DEFAULT[:esse_pagy_search] = :my_method
+```
+
+Now call `UsersIndex.my_method(...)` and `Esse.cluster.my_method(...)`.
+
+## Comparing to esse-kaminari
+
+| Aspect | esse-pagy | esse-kaminari |
+|--------|-----------|---------------|
+| Style | Controller backend | Chainable query methods |
+| Multi-index | Built-in via cluster | Single-index focus |
+| Execution | Deferred until `pagy_esse` | Lazy until `.response` |
+| Best for | Rails controllers, multi-index | Service objects, single-index |


### PR DESCRIPTION
## Summary

Adds `docs/` with three files:

- `README.md` — overview and entry point
- `usage.md` — controller-backend pattern with `pagy_esse` + `pagy_search` and multi-index cluster search
- `api.md` — reference for `Esse::Index.pagy_search`, `Esse::Cluster#pagy_search`, `Pagy.new_from_esse`, and `Pagy::Backend#pagy_esse`

## Test plan

- [ ] Skim `docs/README.md` as a navigation entry point
- [ ] Verify `pagy_esse` controller example matches the current API
- [ ] Verify `Pagy::DEFAULT` config keys in `api.md` are accurate