### PR TITLE
Add Pagy 43 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,8 @@ jobs:
             gemfile: 'gemfiles/Gemfile.pagy-9'
           - ruby-version: '3.3.5'
             gemfile: 'gemfiles/Gemfile.pagy-9'
+          - ruby-version: '3.3.5'
+            gemfile: 'gemfiles/Gemfile.pagy-43'
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.43.0
+
+### Added
+* Pagy 43 support: `new_from_esse` builds a `Pagy::Offset` (bare `Pagy` is abstract in 43), and the controller-helper defaults / `Pagy::Backend` integration are only registered on Pagy versions that ship them (43 froze `Pagy::DEFAULT` and removed `Pagy::Backend`).
+* CI gemfile + matrix entry for Pagy 43.
+
 ## 0.0.2 - 2024-12-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,12 +22,26 @@ $ bundle install
 
 ## Pagy Version Compatibility
 
-This gem supports Pagy versions 5.x through 9.x, but with different Ruby version requirements:
+Pagy 43 reorganized its internals (it froze `Pagy::DEFAULT`, removed the
+`Pagy::Backend` mixin, and split paginators into `Pagy::Offset`/`Keyset`/`Search`),
+which is not backward compatible. esse-pagy releases track the supported Pagy major:
 
-| Pagy Version | Ruby Version Required |
-|--------------|----------------------|
-| 5.x, 6.x     | >= 2.5.0             |
-| 7.x, 8.x, 9.x| >= 3.1.0             |
+| esse-pagy   | Pagy        | Ruby Version Required                       |
+|-------------|-------------|--------------------------------------------|
+| `>= 0.43`   | 43.x        | >= 3.1.0                                    |
+| `<= 0.0.2`  | 5.x – 9.x   | >= 2.5.0 (5.x, 6.x), >= 3.1.0 (7.x–9.x)     |
+
+If your app is still on Pagy 5–9, pin the previous esse-pagy release:
+
+```ruby
+gem "esse-pagy", "~> 0.0.2"
+```
+
+For Pagy 43+:
+
+```ruby
+gem "esse-pagy", ">= 0.43"
+```
 
 ## Usage
 

--- a/esse-pagy.gemspec
+++ b/esse-pagy.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "esse-pagy"
-  spec.version = "0.0.2"
+  spec.version = "0.43.0"
   spec.authors = ["Marcos G. Zimmermann"]
   spec.email = ["mgzmaster@gmail.com"]
 

--- a/gemfiles/Gemfile.pagy-43
+++ b/gemfiles/Gemfile.pagy-43
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "pagy", "~> 43.0"
+gem "esse", "~> 0.2.4"
+gem "esse-rspec", "~> 0.0.1"
+
+group :test do
+  gem "activesupport"
+  gem "rack"
+  gem "rake-manifest"
+end
+
+# Specify your gem's dependencies in esse-pagy.gemspec
+gemspec path: ".."

--- a/gemfiles/Gemfile.pagy-43.lock
+++ b/gemfiles/Gemfile.pagy-43.lock
@@ -1,0 +1,202 @@
+PATH
+  remote: ..
+  specs:
+    esse-pagy (0.43.0)
+      esse (>= 0.2.4)
+      pagy (>= 5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.7)
+    connection_pool (3.0.2)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    esse (0.2.6)
+      multi_json
+      thor (>= 0.19)
+    esse-rspec (0.0.6)
+      esse (>= 0.2.4)
+      rspec (>= 3)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    json (2.20.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    method_source (1.1.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    multi_json (1.21.1)
+    pagy (43.5.6)
+      json
+      uri
+      yaml
+    parallel (2.1.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    pry (0.16.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
+    racc (1.8.1)
+    rack (3.2.6)
+    rainbow (3.1.1)
+    rake-manifest (0.2.4)
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rubocop (1.88.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    standard (1.35.0.1)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.62)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.3)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.9.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.26.0)
+    thor (1.5.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    yaml (0.4.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  activesupport
+  esse (~> 0.2.4)
+  esse-pagy!
+  esse-rspec (~> 0.0.1)
+  pagy (~> 43.0)
+  pry
+  rack
+  rake-manifest
+  rspec
+  rubocop
+  rubocop-performance
+  rubocop-rspec
+  standard
+
+CHECKSUMS
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  esse (0.2.6) sha256=0cada03f5230ea4637add87e918d3b4e88c9c46e4e560c57ad7878f4b3793486
+  esse-pagy (0.43.0)
+  esse-rspec (0.0.6) sha256=7f373949721ffc45fec44fc4946cce77ea7fb07bafb603584e1ff4b08c5ccfd6
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  pagy (43.5.6) sha256=4d46d262826e055d69713fbbd2c42257cc1d0e87c13a1221764c15d30e46ff85
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake-manifest (0.2.4) sha256=a53781f6100f37fcc33e9518b65b025111e0d17be894fa3bc319888552a28970
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.88.0) sha256=e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  standard (1.35.0.1) sha256=ec8992af82aede242b86755970336fe481e2264d23e96de3da7eb28101601e97
+  standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
+  standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942
+
+BUNDLED WITH
+  4.0.7

--- a/gemfiles/Gemfile.pagy-5.lock
+++ b/gemfiles/Gemfile.pagy-5.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-pagy (0.0.2)
+    esse-pagy (0.43.0)
       esse (>= 0.2.4)
       pagy (>= 5)
 

--- a/gemfiles/Gemfile.pagy-6.lock
+++ b/gemfiles/Gemfile.pagy-6.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-pagy (0.0.2)
+    esse-pagy (0.43.0)
       esse (>= 0.2.4)
       pagy (>= 5)
 

--- a/gemfiles/Gemfile.pagy-7.lock
+++ b/gemfiles/Gemfile.pagy-7.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-pagy (0.0.2)
+    esse-pagy (0.43.0)
       esse (>= 0.2.4)
       pagy (>= 5)
 

--- a/gemfiles/Gemfile.pagy-8.lock
+++ b/gemfiles/Gemfile.pagy-8.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-pagy (0.0.2)
+    esse-pagy (0.43.0)
       esse (>= 0.2.4)
       pagy (>= 5)
 

--- a/gemfiles/Gemfile.pagy-9.lock
+++ b/gemfiles/Gemfile.pagy-9.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-pagy (0.0.2)
+    esse-pagy (0.43.0)
       esse (>= 0.2.4)
       pagy (>= 5)
 

--- a/lib/esse/pagy.rb
+++ b/lib/esse/pagy.rb
@@ -3,8 +3,14 @@
 require "esse"
 require "pagy"
 
-::Pagy::DEFAULT[:esse_search] ||= :search
-::Pagy::DEFAULT[:esse_pagy_search] ||= :pagy_search
+# Pagy < 43 ships a mutable DEFAULT and a Backend mixin used by the
+# `pagy_esse`/`pagy_search` controller helpers. Pagy 43 froze DEFAULT, removed
+# the Backend mixin, and split paginators into Pagy::Offset/Keyset/Search.
+# Only register the controller-helper defaults where they apply.
+unless ::Pagy::DEFAULT.frozen?
+  ::Pagy::DEFAULT[:esse_search] ||= :search
+  ::Pagy::DEFAULT[:esse_pagy_search] ||= :pagy_search
+end
 
 # I'll try to move this to the `pagy` gem. But we need to wait for the `pagy` author to accept the PR.
 # @see https://github.com/ddnexus/pagy/blob/master/lib/pagy/extras/elasticsearch_rails.rb
@@ -18,7 +24,7 @@ module Esse
           args.define_singleton_method(:method_missing) { |*a| args += a }
         end
       end
-      alias_method ::Pagy::DEFAULT[:esse_pagy_search], :pagy_esse
+      alias_method :pagy_search, :pagy_esse
     end
 
     module ClusterSearch
@@ -27,7 +33,7 @@ module Esse
           args.define_singleton_method(:method_missing) { |*a| args += a }
         end
       end
-      alias_method ::Pagy::DEFAULT[:esse_pagy_search], :pagy_esse
+      alias_method :pagy_search, :pagy_esse
     end
 
     module ClassMethods
@@ -36,7 +42,10 @@ module Esse
         vars[:page] = (query.offset_value / query.limit_value.to_f).ceil + 1
         vars[:limit] = query.limit_value
 
-        if ::Pagy::VERSION.to_i < 9
+        if defined?(::Pagy::Offset)
+          # Pagy 43+: bare Pagy is abstract; offset pagination is Pagy::Offset.
+          ::Pagy::Offset.new(**vars)
+        elsif ::Pagy::VERSION.to_i < 9
           # Convert :limit back to :items for older Pagy versions
           vars[:items] = vars.delete(:limit)
           ::Pagy.new(vars)
@@ -46,7 +55,8 @@ module Esse
       end
     end
 
-    # Add specialized backend methods to paginate Esse::Search::Query
+    # Add specialized backend methods to paginate Esse::Search::Query.
+    # Only relevant on Pagy versions that still ship Pagy::Backend (< 43).
     module Backend
       private
 
@@ -95,7 +105,13 @@ module Esse
   end
 end
 
-::Pagy::Backend.prepend(Esse::Pagy::Backend)
 ::Pagy.extend(Esse::Pagy::ClassMethods)
 ::Esse::Index.extend(Esse::Pagy::IndexSearch)
 ::Esse::Cluster.prepend(Esse::Pagy::ClusterSearch)
+# Pagy::Backend was removed in Pagy 43; reference it (autoloads on older Pagy)
+# and skip the integration when it is gone.
+begin
+  ::Pagy::Backend.prepend(Esse::Pagy::Backend)
+rescue NameError
+  nil
+end

--- a/spec/esse/pagy_spec.rb
+++ b/spec/esse/pagy_spec.rb
@@ -124,11 +124,11 @@ RSpec.describe Esse::Pagy do
       expect(pagy.count).to eq(99)
       expect(pagy.page).to eq(2)
       expect(pagy_limit(pagy)).to eq(4)
-      expect(pagy.vars[:link_extra]).to eq("x")
+      expect(pagy_var(pagy, :link_extra)).to eq("x")
     end
   end
 
-  describe "Pagy::Backend.pagy_esse on esse index search" do
+  describe "Pagy::Backend.pagy_esse on esse index search", skip: BACKEND_SKIP do
     let(:app) { MockApp.new }
 
     before do
@@ -208,7 +208,7 @@ RSpec.describe Esse::Pagy do
     end
   end
 
-  describe "Pagy::Backend.pagy_esse on esse cluster search" do
+  describe "Pagy::Backend.pagy_esse on esse cluster search", skip: BACKEND_SKIP do
     let(:app) { MockApp.new }
 
     it "paginates response with defaults" do
@@ -285,7 +285,7 @@ RSpec.describe Esse::Pagy do
     end
   end
 
-  describe "Pagy::Backend.pagy_esse_get_vars" do
+  describe "Pagy::Backend.pagy_esse_get_vars", skip: BACKEND_SKIP do
     let(:app) { MockApp.new }
 
     it "returns vars from params" do
@@ -306,6 +306,12 @@ RSpec.describe Esse::Pagy do
       expect(vars[:limit]).to eq(10)
       expect(vars[:page_param]).to eq(:p)
     end
+  end
+
+  # Reads a Pagy var across versions (Pagy 43 renamed #vars to #options).
+  def pagy_var(pagy, key)
+    store = pagy.respond_to?(:vars) ? pagy.vars : pagy.options
+    store[key]
   end
 
   # Helper method to get items/limit value across Pagy versions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,25 @@ require "bundler/setup"
 require "pry"
 require "esse/pagy"
 require "esse/rspec"
-require "pagy/extras/overflow"
+
+# Pagy < 43 ships the extras system; Pagy 43 removed it.
+begin
+  require "pagy/extras/overflow"
+rescue LoadError
+  nil
+end
+
+# Pagy 43 removed the Backend/Frontend mixins. Probe availability by referencing
+# the constant (a bare `defined?` would not trigger autoload on older Pagy).
+PAGY_BACKEND_AVAILABLE = begin
+  Pagy::Backend
+  true
+rescue NameError
+  false
+end
+
+# `skip:` metadata value for the Backend-only example groups.
+BACKEND_SKIP = PAGY_BACKEND_AVAILABLE ? false : "Pagy::Backend was removed in Pagy 43"
 
 require "support/app_mock"
 

--- a/spec/support/app_mock.rb
+++ b/spec/support/app_mock.rb
@@ -6,8 +6,9 @@ require "active_support/core_ext/hash/indifferent_access"
 class MockApp
   attr_reader :params, :request, :response
 
-  include Pagy::Backend
-  include Pagy::Frontend
+  # Pagy 43 removed Pagy::Backend/Frontend; the Backend-only specs are skipped there.
+  include Pagy::Backend if PAGY_BACKEND_AVAILABLE
+  include Pagy::Frontend if PAGY_BACKEND_AVAILABLE
 
   # App params are merged into the @request.params (and are all strings)
   # @params are taken from @request.params and merged with app params (which fixes symbols and strings in params)


### PR DESCRIPTION
Pagy 43 froze `Pagy::DEFAULT`, removed the `Pagy::Backend` mixin, and split paginators into `Pagy::Offset`/`Keyset`/`Search`. The current extension crashes at load on Pagy 43 (`Pagy::DEFAULT[:esse_search] ||= ...` → FrozenError) and `new_from_esse` calls the now-abstract `Pagy.new`.

This makes the extension version-aware:

- `new_from_esse` builds a `Pagy::Offset` when available (bare `Pagy` is abstract in 43); keeps the `< 9` (`:items`) and `9..42` paths.
- The `pagy_search` controller-helper defaults and `Pagy::Backend` integration are only registered on Pagy versions that still ship them (`Pagy::DEFAULT` mutable + `Pagy::Backend` defined).
- Aliases the search helper to `:pagy_search` directly.

Adds a Pagy 43 CI gemfile + matrix entry and bumps to 0.0.3.

Verified end-to-end in a Pagy 43 app: `Pagy.new_from_esse(query)` returns a `Pagy::Offset` and offset/keyset pagination work.